### PR TITLE
fix: update deprecated "svelte" field in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-boring-avatars",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-boring-avatars",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "svelte-boring-avatars",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "svelte": "./dist/index.js"
+    }
+  },
   "module": "dist/index.mjs",
   "main": "dist/index.umd.js",
   "types": "dist/ts/index.d.ts",


### PR DESCRIPTION
Current installations generate a warning. See: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition. 

Kept the old "svelte" field for backwards compatibility as suggested by the docs. 