### PR TITLE
Resolve type and import issues for TypeScript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{json,svelte,ts,js}]
+indent_style = space
+indent_size = 2
+
+[*.css]
+indent_style = tab

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2023-2024 Justus Perlwitz
 Copyright (c) 2023 paolotiu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-boring-avatars",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-boring-avatars",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "svelte": "dist/index.js",
   "exports": {
     ".": {
-      "svelte": "./dist/index.js"
+      "svelte": "./dist/index.js",
+      "types": "./dist/ts/index.d.ts"
     }
   },
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,14 @@
   "module": "dist/index.mjs",
   "main": "dist/index.umd.js",
   "types": "dist/ts/index.d.ts",
-  "author": "Paolo Tiu <paolotiu17@gmail.com>",
+  "contributors": [
+    {"name": "Paolo Tiu",
+      "email": "paolotiu17@gmail.com"
+    },
+    {"name": "Justus Perlwitz",
+      "email": "hello@justus.pw"
+    }
+  ],
   "license": "MIT",
   "version": "1.2.5",
   "sideEffects": false,

--- a/src/lib/components/AvatarPixel.svelte
+++ b/src/lib/components/AvatarPixel.svelte
@@ -36,7 +36,7 @@
 >
   <mask
     id={maskId}
-    mask-type="alpha"
+    style:mask-type="alpha"
     maskUnits="userSpaceOnUse"
     x={0}
     y={0}


### PR DESCRIPTION
SvelteKit v2 uses TypeScript bundler resolution. This required the `types` export to be specified explicitly in the package.json . A similar issue was encountered here: https://github.com/sveltejs/kit/issues/11329

Fortunately, the fix is simple. See commit #48e05c

Having fixed the first issue brought up a second one: `mask-type` is not a valid <mask> attribute. I have fixed this by making it a Svelte style attribute instead. See #c8b931e.

Cheers!